### PR TITLE
cyclonedds: Set CMAKE_INSTALL_LIBDIR to lib unconditionally

### DIFF
--- a/modules/cyclonedds/0.10.5-5-g76360fb7.iw.1/overlay/BUILD.bazel
+++ b/modules/cyclonedds/0.10.5-5-g76360fb7.iw.1/overlay/BUILD.bazel
@@ -88,6 +88,8 @@ filegroup(
 cache_entries = {
     "CMAKE_POSITION_INDEPENDENT_CODE": "ON",  # Must be set!
     "BUILD_SHARED_LIBS": "OFF",
+    # Certain multilib distros install 64-bit binaries to /usr/lib64.
+    "CMAKE_INSTALL_LIBDIR": "lib",
     # CycloneDDS specific options.
     "APPEND_PROJECT_NAME_TO_INCLUDEDIR": "OFF",
     "BUILD_DDSPERF": "OFF",

--- a/modules/cyclonedds/0.10.5-5-g76360fb7.iw.1/source.json
+++ b/modules/cyclonedds/0.10.5-5-g76360fb7.iw.1/source.json
@@ -3,8 +3,7 @@
   "integrity": "sha256-4N1LYZATvoDj0zfeTDzet+hPDhxRRVID1xWqTEhR6ns=",
   "strip_prefix": "cyclonedds-76360fb73907ce3dba397e89090a7a4ecf4f1246",
   "overlay": {
-    "MODULE.bazel": "sha256-Hz0uIAEcFu5QRl6+JGRhL6R3UVMkxa+0NfILCsFX/V8=",
-    "BUILD.bazel": "sha256-Lb1ZWp5ChmLEshZPLei7L72dJkwQZoLpoWPX6dXaeG8="
+    "MODULE.bazel": "sha256-d8lVjcNCZ42pAIDSL9XJdF32UNoHyf6Cq3Fn8m9eCeg=",
+    "BUILD.bazel": "sha256-leSB/rLCvRY+9er/hWAEswIFmzo0h9hrHb9TjWN/xqs="
   }
 }
-


### PR DESCRIPTION
Certain distros set the libdir for 64-bit libraries to /usr/lib64. This change leaks to CMake in rules_foreign_cc, so it can't find the library it just built. This makes it so that the same path is always used.